### PR TITLE
fix: tdgpt port (5000) conflict on macos

### DIFF
--- a/docker/docker-compose-tdgpt.yml
+++ b/docker/docker-compose-tdgpt.yml
@@ -7,9 +7,9 @@ services:
     environment:
       TZ: "${TZ:-UTC}"
     ports:
-      - "6090:6090"
-      - "5000:5000"
-      - "5001:5001"
+      - "6070:6090"
+      - "6071:5000"
+      - "6072:5001"
     networks:
       - taos_net
     healthcheck:


### PR DESCRIPTION
Signed-off-by: WANG Xu <feici02@outlook.com>

# Description

Port 5000 is occupied by ControlCenter on macOS.

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
