### PR TITLE
refactor: change ports used by tdgpt

### DIFF
--- a/docker/README-CN.md
+++ b/docker/README-CN.md
@@ -71,9 +71,9 @@ docker compose -f docker-compose-tdgpt.yml down
 ```
 
 **额外端口：**
-- **6090**: TDgpt 主服务端口
-- **5000**: 模型服务端口
-- **5001**: 扩展模型服务端口
+- **6035**: TDgpt 主服务端口
+- **6036**: 模型服务端口
+- **6037**: 扩展模型服务端口
 
 **服务启动顺序：**
 1. **TDgpt 服务**: 优先启动，提供 AI 分析能力
@@ -83,7 +83,7 @@ docker compose -f docker-compose-tdgpt.yml down
 ## 健康检查
 
 所有服务都配置了健康检查机制，确保服务按正确顺序启动：
-- **TDgpt**: 检查 6090 端口可用性
+- **TDgpt**: 检查 6035 端口可用性
 - **TSDB Enterprise**: 检查数据库连接状态
 - **IDMP**: 检查 6042 端口可用性
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,9 +71,9 @@ docker compose -f docker-compose-tdgpt.yml down
 ```
 
 **Additional Ports:**
-- **6090**: TDgpt main service port
-- **5000**: Model service port
-- **5001**: Extended model service port
+- **6035**: TDgpt main service port
+- **6036**: Model service port
+- **6037**: Extended model service port
 
 **Service Startup Order:**
 1. **TDgpt Service**: Starts first, providing AI analysis capabilities
@@ -83,7 +83,7 @@ docker compose -f docker-compose-tdgpt.yml down
 ## Health Checks
 
 All services are configured with health check mechanisms to ensure services start in the correct order:
-- **TDgpt**: Checks port 6090 availability
+- **TDgpt**: Checks port 6035 availability
 - **TSDB Enterprise**: Checks database connection status
 - **IDMP**: Checks port 6042 availability
 

--- a/docker/docker-compose-tdgpt.yml
+++ b/docker/docker-compose-tdgpt.yml
@@ -7,13 +7,13 @@ services:
     environment:
       TZ: "${TZ:-UTC}"
     ports:
-      - "6070:6090"
-      - "6071:5000"
-      - "6072:5001"
+      - "6035:6035"
+      - "6036:6036"
+      - "6037:6037"
     networks:
       - taos_net
     healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:6090').read()"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:6035').read()"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/init-anode.sql
+++ b/docker/init-anode.sql
@@ -1,2 +1,2 @@
 -- Initialize TDengine TSDB anode for TDGPT service
-create anode "tdengine-tdgpt:6090";
+create anode "tdengine-tdgpt:6035";


### PR DESCRIPTION
Signed-off-by: WANG Xu <feici02@outlook.com>

# Description

Change ports used by TDgpt:
- 6035
- 6036
- 6037

Jira: https://jira.taosdata.com:18080/browse/TD-

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
