### PR TITLE
fix(docker): use service name as fqdn in tsdb container

### DIFF
--- a/docker/docker-compose-tdgpt.yml
+++ b/docker/docker-compose-tdgpt.yml
@@ -32,6 +32,7 @@ services:
     environment:
       TZ: "${TZ:-UTC}"
       EXPLORER_SKIP_REGISTER: "${EXPLORER_SKIP_REGISTER:-true}"
+      TAOS_FQDN: "${TAOS_FQDN:-tdengine-tsdb}"
     ports:
       - "6030:6030"
       - "6041:6041"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       TZ: "${TZ:-UTC}"
       EXPLORER_SKIP_REGISTER: "${EXPLORER_SKIP_REGISTER:-true}"
+      TAOS_FQDN: "${TAOS_FQDN:-tdengine-tsdb}"
     ports:
       - "6030:6030"
       - "6041:6041"


### PR DESCRIPTION
So that `docker compose down` (without `-v`) will work as expected.

# Description

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
